### PR TITLE
Fix deprecated error

### DIFF
--- a/library/Uuid/Uuid.php
+++ b/library/Uuid/Uuid.php
@@ -45,9 +45,9 @@ class Uuid {
      * @throws \UnexpectedValueException
      */
     public function setUuid($chars = null){
-        if (null === $chars && 32 != strlen($chars)) {
+        if (is_null($chars)) {
             $chars = md5 ( uniqid ( mt_rand (), true ) );
-        } elseif ($chars !== null && 32 !== strlen($chars)){
+        } elseif (32 !== strlen($chars)){
             throw new \UnexpectedValueException('invalid characters for UUID generation provided');
         }
         $this->uuid =


### PR DESCRIPTION
On php 8.1 calling Uuid::generate() (without a parameter) generates a E_DEPRECATED error message:

` DEPRECATED  strlen(): Passing null to parameter #1 ($string) of type string is deprecated in vendor/zircote/uuid/library/Uuid/Uuid.php on line 48.`


This commit prevents that message.